### PR TITLE
[Feat] 도메인 모델 및 API 기본 구조 설정

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/AuthController.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.mindwalk.domain.auth.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormthon.backend.mindwalk.domain.auth.api.docs.AuthControllerDocs;
+import com.goormthon.backend.mindwalk.domain.auth.application.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController implements AuthControllerDocs {
+
+	private final AuthService authService;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/docs/AuthControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/docs/AuthControllerDocs.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.auth.api.docs;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[1. 인증]", description = "인증 관련 API")
+public interface AuthControllerDocs {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/AuthService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/AuthService.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.auth.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/api/CheckpointController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/api/CheckpointController.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.mindwalk.domain.checkpoint.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormthon.backend.mindwalk.domain.checkpoint.api.docs.CheckpointControllerDocs;
+import com.goormthon.backend.mindwalk.domain.checkpoint.application.CheckpointService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/checkpoint")
+public class CheckpointController implements CheckpointControllerDocs {
+
+	private final CheckpointService checkpointService;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/api/docs/CheckpointControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/api/docs/CheckpointControllerDocs.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.checkpoint.api.docs;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[4. 체크 포인트]", description = "체크 포인트 관련 API")
+public interface CheckpointControllerDocs {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/application/CheckpointService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/application/CheckpointService.java
@@ -1,0 +1,14 @@
+package com.goormthon.backend.mindwalk.domain.checkpoint.application;
+
+import org.springframework.stereotype.Service;
+
+import com.goormthon.backend.mindwalk.domain.checkpoint.dao.CheckpointRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CheckpointService {
+
+	private final CheckpointRepository checkpointRepository;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/dao/CheckpointRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/dao/CheckpointRepository.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.checkpoint.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goormthon.backend.mindwalk.domain.checkpoint.domain.Checkpoint;
+
+@Repository
+public interface CheckpointRepository extends JpaRepository<Checkpoint, Long> {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/domain/Checkpoint.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/domain/Checkpoint.java
@@ -1,0 +1,50 @@
+package com.goormthon.backend.mindwalk.domain.checkpoint.domain;
+
+import com.goormthon.backend.mindwalk.domain.common.BaseTimeEntity;
+import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMission;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "checkpoint")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Checkpoint extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "checkpoint_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private Long sequence;
+
+	@Column(nullable = false)
+	private Double latitude;
+
+	@Column(nullable = false)
+	private Double longitude;
+
+	@Enumerated(EnumType.STRING)
+	private VisitStatus status;
+
+	@Enumerated(EnumType.STRING)
+	private HealingContentType healingContentType;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "walk_mission_id")
+	private WalkMission walkMission;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/domain/HealingContentType.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/domain/HealingContentType.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.checkpoint.domain;
+
+public enum HealingContentType {
+	GRATITUDE_THANKS, // 감사 인사
+	PRAISE,           // 칭찬하기
+	SHORT_MEDITATION, // 짧은 명상
+	FIND_COLOR,       // 색깔 찾기
+	STRETCHING,       // 스트레칭
+	RHYTHM_WALKING    // 리듬 워킹
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/domain/VisitStatus.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/checkpoint/domain/VisitStatus.java
@@ -1,0 +1,6 @@
+package com.goormthon.backend.mindwalk.domain.checkpoint.domain;
+
+public enum VisitStatus {
+	NOT_VISITED,
+	VISITED
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/common/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.goormthon.backend.mindwalk.domain.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/GardenController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/GardenController.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.mindwalk.domain.garden.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormthon.backend.mindwalk.domain.garden.api.docs.GardenControllerDocs;
+import com.goormthon.backend.mindwalk.domain.garden.application.GardenService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/gardens")
+public class GardenController implements GardenControllerDocs {
+
+	private final GardenService gardenService;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.garden.api.docs;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[5. 마음 정원]", description = "마음 정원 관련 API")
+public interface GardenControllerDocs {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/application/GardenService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/application/GardenService.java
@@ -1,0 +1,14 @@
+package com.goormthon.backend.mindwalk.domain.garden.application;
+
+import org.springframework.stereotype.Service;
+
+import com.goormthon.backend.mindwalk.domain.garden.dao.GardenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GardenService {
+
+	private final GardenRepository gardenRepository;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenRepository.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.garden.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goormthon.backend.mindwalk.domain.garden.domain.Garden;
+
+@Repository
+public interface GardenRepository extends JpaRepository<Garden, Long> {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/FlowerType.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/FlowerType.java
@@ -1,0 +1,8 @@
+package com.goormthon.backend.mindwalk.domain.garden.domain;
+
+public enum FlowerType {
+	ROSE,
+	SUNFLOWER,
+	LILY,
+	LAVENDER
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/Garden.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/Garden.java
@@ -1,0 +1,33 @@
+package com.goormthon.backend.mindwalk.domain.garden.domain;
+
+import com.goormthon.backend.mindwalk.domain.common.BaseTimeEntity;
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "garden")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Garden extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "garden_id")
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
@@ -1,0 +1,43 @@
+package com.goormthon.backend.mindwalk.domain.garden.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "garden_plant")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class GardenPlant {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "garden_plant_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "plant_stage", nullable = false)
+	private PlantStage plantStage;
+
+	@Column(name = "growth_point", nullable = false)
+	private Long growthPoint;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "flower_type", nullable = false)
+	private FlowerType flowerType;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "garden_id")
+	private Garden garden;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/PlantStage.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/PlantStage.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.garden.domain;
+
+public enum PlantStage {
+	SEED,
+	SPROUT,
+	FLOWER
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/notification/api/NotificationController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/notification/api/NotificationController.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.mindwalk.domain.notification.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormthon.backend.mindwalk.domain.notification.api.docs.NotificationApi;
+import com.goormthon.backend.mindwalk.domain.notification.application.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController implements NotificationApi {
+
+	private final NotificationService notificationService;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/notification/api/docs/NotificationApi.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/notification/api/docs/NotificationApi.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.notification.api.docs;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[7. 알림]", description = "알림 관련 API")
+public interface NotificationApi {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/notification/application/NotificationService.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.notification.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/ReportController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/ReportController.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.mindwalk.domain.report.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormthon.backend.mindwalk.domain.report.api.docs.ReportControllerDocs;
+import com.goormthon.backend.mindwalk.domain.report.application.ReportService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ReportController implements ReportControllerDocs {
+
+	private final ReportService reportService;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/docs/ReportControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/docs/ReportControllerDocs.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.report.api.docs;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[6. 주간 요약]", description = "주간 요약 관련 API")
+public interface ReportControllerDocs {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/application/ReportService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/application/ReportService.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.report.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/UserController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/UserController.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.mindwalk.domain.user.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormthon.backend.mindwalk.domain.user.api.docs.UserControllerDocs;
+import com.goormthon.backend.mindwalk.domain.user.application.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController implements UserControllerDocs {
+
+	private final UserService userService;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/docs/UserControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/docs/UserControllerDocs.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.user.api.docs;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[2. 회원]", description = "회원 관련 API")
+public interface UserControllerDocs {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
@@ -1,0 +1,14 @@
+package com.goormthon.backend.mindwalk.domain.user.application;
+
+import org.springframework.stereotype.Service;
+
+import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/dao/UserRepository.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.user.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/domain/User.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/domain/User.java
@@ -1,0 +1,43 @@
+package com.goormthon.backend.mindwalk.domain.user.domain;
+
+import com.goormthon.backend.mindwalk.domain.common.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@EqualsAndHashCode(of = "id", callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id")
+	private Long id;
+
+	@Column(name = "oauth_id", unique = true)
+	private Long oauthId;
+
+	@Column(name = "nickname")
+	private String nickname;
+
+	@Builder
+	public User(Long oauthId) {
+		this.oauthId = oauthId;
+	}
+
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/WalkMissionController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/WalkMissionController.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.mindwalk.domain.walkmission.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormthon.backend.mindwalk.domain.walkmission.api.docs.WalkMissionControllerDocs;
+import com.goormthon.backend.mindwalk.domain.walkmission.application.WalkMissionService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/missions")
+public class WalkMissionController implements WalkMissionControllerDocs {
+
+	private final WalkMissionService walkMissionService;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/docs/WalkMissionControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/docs/WalkMissionControllerDocs.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.walkmission.api.docs;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[3. 산책 미션]", description = "산책 미션 관련 API")
+public interface WalkMissionControllerDocs {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/application/WalkMissionService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/application/WalkMissionService.java
@@ -1,0 +1,14 @@
+package com.goormthon.backend.mindwalk.domain.walkmission.application;
+
+import org.springframework.stereotype.Service;
+
+import com.goormthon.backend.mindwalk.domain.walkmission.dao.WalkMissionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WalkMissionService {
+
+	private final WalkMissionRepository walkMissionRepository;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dao/WalkMissionRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dao/WalkMissionRepository.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.walkmission.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMission;
+
+@Repository
+public interface WalkMissionRepository extends JpaRepository<WalkMission, Long> {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMission.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMission.java
@@ -1,0 +1,56 @@
+package com.goormthon.backend.mindwalk.domain.walkmission.domain;
+
+import com.goormthon.backend.mindwalk.domain.common.BaseTimeEntity;
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "walk_mission")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class WalkMission extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "walk_mission_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	private WalkMissionStatus status;
+
+	@Column(name = "steps")
+	private Long steps;
+
+	@Column(name = "distance_meters")
+	private Long distanceMeters;
+
+	@Column(name = "actual_duration_minutes")
+	private Long actualDurationMinutes;
+
+	@Column(name = "end_latitude", nullable = false)
+	private Double endLatitude;
+
+	@Column(name = "end_longitude", nullable = false)
+	private Double endLongitude;
+
+	@Column(name = "target_duration_minutes", nullable = false)
+	private Long targetDurationMinutes;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMissionStatus.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMissionStatus.java
@@ -1,0 +1,7 @@
+package com.goormthon.backend.mindwalk.domain.walkmission.domain;
+
+public enum WalkMissionStatus {
+	IN_PROGRESS,
+	COMPLETED,
+	CANCELED
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,78 @@
+package com.goormthon.backend.mindwalk.global.config.swagger;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+	private static final String SERVER_NAME = "MindWalk";
+	private static final String GITHUB_URL = "https://github.com/9oormthon-univ/2025_SEASONTHON_TEAM_81_BE";
+	private static final String SWAGGER_API_TITLE = "MindWalk 프로젝트 API 문서";
+	private static final String SWAGGER_API_DESCRIPTION = "MindWalk 프로젝트 API 문서입니다.";
+
+	@Value("${swagger.version:0.0.1}")
+	private String version;
+
+	@Value("${swagger.server-url:http://localhost:8080}")
+	private String serverUrl;
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.servers(swaggerServers())
+			.components(authSetting())
+			.info(swaggerInfo())
+			.addSecurityItem(new SecurityRequirement().addList("accessToken"));
+	}
+
+	private List<Server> swaggerServers() {
+		Server server = new Server().url(serverUrl).description(SWAGGER_API_DESCRIPTION);
+		return List.of(server);
+	}
+
+	private Components authSetting() {
+		return new Components()
+			.addSecuritySchemes(
+				"accessToken",
+				new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization"));
+	}
+
+	private Info swaggerInfo() {
+		License license = new License();
+		license.setUrl(GITHUB_URL);
+		license.setName(SERVER_NAME);
+
+		return new Info()
+			.title(SWAGGER_API_TITLE)
+			.version("v" + version)
+			.description(SWAGGER_API_DESCRIPTION)
+			.license(license);
+	}
+
+	@Bean
+	public ModelResolver modelResolver(ObjectMapper objectMapper) {
+		return new ModelResolver(objectMapper);
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/global/config/web/WebConfig.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/global/config/web/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("*")
+			.allowedOriginPatterns("*")
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 			.allowedHeaders("*")
 			.allowCredentials(true);

--- a/src/main/resources/application-docs.yml
+++ b/src/main/resources/application-docs.yml
@@ -1,0 +1,20 @@
+spring:
+  config:
+    activate:
+      on-profile: "docs"
+
+swagger:
+  version: ${SWAGGER_VERSION:0.0.1}
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui
+    disable-swagger-default-url: true
+    display-request-duration: true
+    tags-sorter: alpha
+    operations-sorter: alpha
+    doc-expansion: none
+    syntax-highlight:
+      theme: none

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,5 +5,7 @@ spring:
       local: "local, datasource"
       dev: "dev, datasource"
       prod: "prod, datasource"
+    include:
+      - docs
   jpa:
     open-in-view: false


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #3 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
#### 1. 도메인 모델 및 API 기본 구조 설정
- `api`, `application`, `dao`, `domain`, `dto`
#### 2. Swagger API 문서 설정
- `SwaggerConfig`와 `application-docs.yml`을 추가하여 API 문서 자동화를 위한 기본 설정 작업 진행
-  Swagger 어노테이션을 분리하기 위한 `docs` 인터페이스를 각 `Controller`에 적용
#### 3. CORS 설정 변경
- `WebConfig`에서 CORS 설정을 `allowedOrigins`에서 `allowedOriginPatterns`로 수정

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
Entity 간의 관계는 우선 모두 단방향으로 설계했습니다..! 
개발 하시면서 반대 방향으로 조회가 꼭 필요하거나 JPQL 쿼리가 복잡해지는 경우에 양방향으로 전환하시면 될 것 같습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced interactive API documentation (Swagger UI) at /swagger-ui with JWT bearer auth and grouped tags (Auth, Users, Walk Missions, Checkpoints, Garden, Reports, Notifications). Endpoints will appear as they are added.
- Configuration
  - Improved CORS origin matching for broader compatibility.
  - Enabled a docs profile to configure Swagger UI defaults (sorting, expansion, request duration).
- Chores
  - Established backend scaffolding for authentication, user management, walk missions, checkpoints, garden, reports, and notifications to support upcoming features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->