### PR TITLE
[Deploy] GitHub Actions를 이용한 CI/CD 배포 자동화 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Database
+DB_HOST=db_host
+DB_USERNAME=username
+DB_PASSWORD=password
+
+# JWT
+JWT_SECRET_KEY=jwt_secret_key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,77 @@
+name: MindWalk CI/CD Workflow
+
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle Caching
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build without test
+        run: ./gradlew clean build -x test
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ap-northeast-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Docker Image And Push to AWS ECR
+        run: |
+          docker build -t mindwalk-server .
+          docker tag mindwalk-server ${{ steps.login-ecr.outputs.registry }}/mindwalk-server:latest
+          docker push ${{ steps.login-ecr.outputs.registry }}/mindwalk-server:latest
+
+      - name: AWS EC2 Server Deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            # .env 파일 생성
+            echo "${{ secrets.ENV_PROD }}" > .env
+
+            # 컨테이너 중지, 삭제 및 이미지 pull
+            docker stop mindwalk-server || true
+            docker rm mindwalk-server || true
+            docker pull ${{ steps.login-ecr.outputs.registry }}/mindwalk-server:latest
+
+            # 컨테이너 실행
+            docker run -d --name mindwalk-server -p 8080:8080 \
+              --env-file .env \
+              ${{ steps.login-ecr.outputs.registry }}/mindwalk-server:latest
+            
+            # 사용하지 않는 도커 리소스 삭제
+            docker system prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### config yml ###
+.env

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "prod"
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
 
 management:
   endpoints:


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #7 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
#### `develop` 브랜치에 푸시될 때, 자동으로 빌드 및 AWS EC2에 배포하는 CI/CD 파이프라인을 구축
- GitHub Actions 워크플로우(`.github/workflows/deploy.yml`) 추가
- Gradle 빌드, Docker 이미지 생성, ECR 푸시, EC2 배포 자동화
- 배포 환경 구성을 위한 `.env.example` 및 `.gitignore` 설정 추가
- `prod` 프로필의 `ddl-auto` 옵션을 `create`로 변경

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 현재 DB 스키마의 변경 가능성이 높아서 prod 프로필 ddl-auto 옵션을 create로 수정했습니다.
- 추후에 완전히 확정된 후에는 validate나 none으로 변경하면 좋을 것 같습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 환경 변수 예시 파일(.env.example) 추가로 데이터베이스/JWT 샘플 설정 제공
  - .gitignore에 .env 무시 규칙 추가
  - CI/CD 워크플로우 도입: 개발 브랜치 푸시 시 빌드·도커 이미지 생성·배포 자동화
- Configuration
  - 프로덕션 설정에서 DB 스키마 처리 동작을 ‘create’로 변경 (애플리케이션 시작 시 스키마 생성)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->