### PR TITLE
[Feat] 카카오 로그인 및 JWT 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/AuthController.java
@@ -1,11 +1,17 @@
 package com.goormthon.backend.mindwalk.domain.auth.api;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goormthon.backend.mindwalk.domain.auth.api.docs.AuthControllerDocs;
 import com.goormthon.backend.mindwalk.domain.auth.application.AuthService;
+import com.goormthon.backend.mindwalk.domain.auth.dto.AuthRequest;
+import com.goormthon.backend.mindwalk.domain.auth.dto.AuthResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -14,4 +20,9 @@ import lombok.RequiredArgsConstructor;
 public class AuthController implements AuthControllerDocs {
 
 	private final AuthService authService;
+
+	@PostMapping("/login")
+	public BaseResponse<AuthResponse> login(@Valid @RequestBody AuthRequest request) {
+		return BaseResponse.success(authService.login(request));
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/docs/AuthControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/api/docs/AuthControllerDocs.java
@@ -1,7 +1,30 @@
 package com.goormthon.backend.mindwalk.domain.auth.api.docs;
 
+import com.goormthon.backend.mindwalk.domain.auth.dto.AuthRequest;
+import com.goormthon.backend.mindwalk.domain.auth.dto.AuthResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "[1. 인증]", description = "인증 관련 API")
 public interface AuthControllerDocs {
+
+	@Operation(
+		summary = "카카오 로그인",
+		description = "카카오 소셜 로그인을 통해 사용자를 인증하고, 신규 사용자인 경우 자동으로 가입 처리 후 토큰을 발급합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "로그인 성공 및 토큰 발급",
+			content = @Content(schema = @Schema(implementation = AuthResponse.class))),
+		@ApiResponse(responseCode = "400", description = "요청 본문이 비어있거나 oauthId가 유효하지 않은 경우",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+		@ApiResponse(responseCode = "500", description = "서버 내부 오류",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+	})
+	public BaseResponse<AuthResponse> login(AuthRequest request);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/AuthService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/AuthService.java
@@ -1,10 +1,35 @@
 package com.goormthon.backend.mindwalk.domain.auth.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormthon.backend.mindwalk.domain.auth.dto.AuthRequest;
+import com.goormthon.backend.mindwalk.domain.auth.dto.AuthResponse;
+import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+	private final JwtProvider jwtProvider;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public AuthResponse login(AuthRequest request) {
+		User user = findOrCreateUser(request.oauthId());
+		return jwtProvider.issueToken(user.getId());
+	}
+
+	private User findOrCreateUser(Long oauthId) {
+		return userRepository.findByOauthId(oauthId)
+			.orElseGet(() -> {
+				User newUser = User.builder()
+					.oauthId(oauthId)
+					.build();
+				return userRepository.save(newUser);
+			});
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/JwtProvider.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/JwtProvider.java
@@ -1,0 +1,67 @@
+package com.goormthon.backend.mindwalk.domain.auth.application;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.goormthon.backend.mindwalk.domain.auth.dto.AuthResponse;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+	private final RedisTokenService redisTokenService;
+	private final SecretKey secretKey;
+
+	@Value("${jwt.accessTokenExpiry}")
+	private long accessTokenExpiry;
+
+	@Value("${jwt.refreshTokenExpiry}")
+	private long refreshTokenExpiry;
+
+	public AuthResponse issueToken(Long userId) {
+		String accessToken = generateAccessToken(userId);
+		String refreshToken = generateRefreshToken(userId);
+
+		redisTokenService.saveRefreshToken(
+			userId,
+			refreshToken,
+			refreshTokenExpiry,
+			TimeUnit.MILLISECONDS
+		);
+		return new AuthResponse(userId, accessToken, refreshToken);
+	}
+
+	public String generateAccessToken(Long userId) {
+		return Jwts.builder()
+			.subject(String.valueOf(userId))
+			.expiration(new Date(System.currentTimeMillis() + accessTokenExpiry))
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public String generateRefreshToken(Long userId) {
+		return Jwts.builder()
+			.subject(String.valueOf(userId))
+			.expiration(new Date(System.currentTimeMillis() + refreshTokenExpiry))
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public Claims parseToken(String token) {
+		return Jwts.parser()
+			.verifyWith(secretKey)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/RedisTokenService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/RedisTokenService.java
@@ -1,0 +1,32 @@
+package com.goormthon.backend.mindwalk.domain.auth.application;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisTokenService {
+
+	private final StringRedisTemplate redisTemplate;
+
+	public RedisTokenService(StringRedisTemplate redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public void saveRefreshToken(Long userId, String refreshToken, long duration, TimeUnit timeUnit) {
+		String key = "refresh:" + userId;
+		redisTemplate.opsForValue()
+			.set(key, refreshToken, duration, timeUnit);
+	}
+
+	public String getRefreshToken(Long userId) {
+		String key = "refresh:" + userId;
+		return redisTemplate.opsForValue().get(key);
+	}
+
+	public void deleteRefreshToken(Long userId) {
+		String key = "refresh:" + userId;
+		redisTemplate.delete(key);
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/config/JwtConfig.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/config/JwtConfig.java
@@ -1,0 +1,20 @@
+package com.goormthon.backend.mindwalk.domain.auth.config;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.jsonwebtoken.security.Keys;
+
+@Configuration
+public class JwtConfig {
+
+	@Bean
+	public SecretKey secretKey(@Value("${jwt.secret}") String secret) {
+		return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/dto/AuthRequest.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/dto/AuthRequest.java
@@ -1,0 +1,9 @@
+package com.goormthon.backend.mindwalk.domain.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AuthRequest (
+	@NotNull(message = "oauthId는 필수입니다.")
+	Long oauthId
+) {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/dto/AuthResponse.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/dto/AuthResponse.java
@@ -1,0 +1,8 @@
+package com.goormthon.backend.mindwalk.domain.auth.dto;
+
+public record AuthResponse (
+	Long userId,
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/dao/UserRepository.java
@@ -1,5 +1,7 @@
 package com.goormthon.backend.mindwalk.domain.user.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.goormthon.backend.mindwalk.domain.user.domain.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByOauthId(Long oauthId);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,3 +10,13 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+jwt:
+  secret: ${SECRET}
+  accessTokenExpiry: ${ACCESS_TOKEN_EXPIRY}
+  refreshTokenExpiry: ${REFRESH_TOKEN_EXPIRY}


### PR DESCRIPTION
## 📣 Related Issue
- close #9

## 📝 Summary
카카오 소셜 로그인 및 JWT 기반 인증 시스템을 구현
사용자가 제공한 oauthId를 기반으로 신규 회원은 자동 가입 처리하고, 기존 회원은 로그인 처리 후 JWT(Access Token, Refresh Token)를 발급

#### 1.카카오 로그인 API
- oauthId 존재 여부에 따라 사용자를 조회하거나 DB에 새로 저장
- 요청 시 oauthId가 누락되지 않도록 @Valid를 이용한 유효성 검사 추가

#### 2.JWT 인증 시스템
- 로그인 성공 시, Access Token과 Refresh Token을 생성하여 응답
- 발급된 Refresh Token은 Redis에 저장하여 관리
- 환경 변수로부터 Secret Key를 안전하게 주입받기 위한 JwtConfig 구성


## 🙏PR point
redis 사용이 처음이라 어려운 부분이 많았습니다! 리뷰 남겨주시면 꼼꼼히 보고 수정할게요~

## 📬 Reference