### PR TITLE
[Feat] 회원 정보 관리

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/JwtProvider.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/JwtProvider.java
@@ -4,7 +4,6 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -57,7 +56,12 @@ public class JwtProvider {
 			.compact();
 	}
 
-	public Claims parseToken(String token) {
+	public Long extractUserIdFromToken(String token) {
+		String subject = parseToken(token).getSubject();
+		return Long.parseLong(subject);
+	}
+
+	private Claims parseToken(String token) {
 		return Jwts.parser()
 			.verifyWith(secretKey)
 			.build()

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/presentation/AuthenticatedIdResolver.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/presentation/AuthenticatedIdResolver.java
@@ -1,0 +1,60 @@
+package com.goormthon.backend.mindwalk.domain.auth.presentation;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.goormthon.backend.mindwalk.domain.auth.application.JwtProvider;
+import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
+import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
+import com.goormthon.backend.mindwalk.global.exception.BaseException;
+import com.goormthon.backend.mindwalk.global.exception.BaseResponseStatus;
+
+import io.micrometer.common.lang.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedIdResolver implements HandlerMethodArgumentResolver {
+	private static final String AUTH_HEADER = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final JwtProvider jwtProvider;
+	private final UserRepository userRepository;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthenticatedId.class)
+			&& parameter.getParameterType().equals(Long.class);
+	}
+
+	@Override
+	public Object resolveArgument(@Nullable MethodParameter parameter,
+		@Nullable ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		@Nullable WebDataBinderFactory binderFactory) {
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		String authHeader = request.getHeader(AUTH_HEADER);
+
+		if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+			throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+
+		}
+		String token = authHeader.substring(BEARER_PREFIX.length());
+
+		Long userId = jwtProvider.extractUserIdFromToken(token);
+
+		if (userId == null) {
+			throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+		}
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND))
+			.getId();
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/presentation/annotation/AuthenticatedId.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/presentation/annotation/AuthenticatedId.java
@@ -1,0 +1,11 @@
+package com.goormthon.backend.mindwalk.domain.auth.presentation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedId {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/UserController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/UserController.java
@@ -1,11 +1,21 @@
 package com.goormthon.backend.mindwalk.domain.user.api;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
 import com.goormthon.backend.mindwalk.domain.user.api.docs.UserControllerDocs;
 import com.goormthon.backend.mindwalk.domain.user.application.UserService;
+import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNicknameRequest;
+import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNotificationRequest;
+import com.goormthon.backend.mindwalk.domain.user.dto.response.UserInfoResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -14,4 +24,30 @@ import lombok.RequiredArgsConstructor;
 public class UserController implements UserControllerDocs {
 
 	private final UserService userService;
+
+	@PostMapping("/nickname")
+	public BaseResponse<Void> createNickname(@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
+		@RequestBody UserNicknameRequest request) {
+		userService.assignNickname(currentUserId, request);
+		return BaseResponse.success();
+	}
+
+	@PutMapping("/nickname")
+	public BaseResponse<Void> updateNickname(@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
+		@RequestBody UserNicknameRequest request) {
+		userService.assignNickname(currentUserId, request);
+		return BaseResponse.success();
+	}
+
+	@GetMapping("/me")
+	public BaseResponse<UserInfoResponse> getUserInfo(@Parameter(hidden = true) @AuthenticatedId Long currentUserId) {
+		return BaseResponse.success(userService.getUserInfo(currentUserId));
+	}
+
+	@PutMapping("/me")
+	public BaseResponse<Void> updateUser(@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
+		@RequestBody UserNotificationRequest request) {
+		userService.updateUser(currentUserId, request);
+		return BaseResponse.success();
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/docs/UserControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/docs/UserControllerDocs.java
@@ -1,7 +1,78 @@
 package com.goormthon.backend.mindwalk.domain.user.api.docs;
 
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
+import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNicknameRequest;
+import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNotificationRequest;
+import com.goormthon.backend.mindwalk.domain.user.dto.response.UserInfoResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "[2. 회원]", description = "회원 관련 API")
 public interface UserControllerDocs {
+
+	@Operation(
+		summary = "회원 닉네임 등록",
+		description = "사용자의 닉네임을 등록합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "닉네임 등록 성공"),
+		@ApiResponse(responseCode = "400", description = "요청 본문이 비어있거나 닉네임 형식이 유효하지 않은 경우",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+	})
+	BaseResponse<Void> createNickname(
+		@Parameter(hidden = true) @AuthenticatedId Long userId,
+		@Valid @RequestBody UserNicknameRequest request
+	);
+
+	@Operation(
+		summary = "회원 닉네임 수정",
+		description = "사용자의 닉네임을 수정합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "닉네임 수정 성공"),
+		@ApiResponse(responseCode = "400", description = "요청 본문이 비어있거나 닉네임 형식이 유효하지 않은 경우",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+	})
+	public BaseResponse<Void> updateNickname(@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
+		@RequestBody UserNicknameRequest request);
+
+	@Operation(
+		summary = "회원 정보 조회",
+		description = "현재 로그인된 사용자의 정보를 조회합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "내 정보 조회 성공",
+			content = @Content(schema = @Schema(implementation = UserInfoResponse.class))),
+		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+			content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+	})
+	BaseResponse<UserInfoResponse> getUserInfo(
+		@Parameter(hidden = true) @AuthenticatedId Long userId
+	);
+
+	@Operation(
+		summary = "회원 알림 설정 수정",
+		description = "사용자의 푸시 알림 등 설정을 수정합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "설정 수정 성공")
+	})
+	BaseResponse<Void> updateUser(@Parameter(hidden = true) @AuthenticatedId Long userId,
+		@RequestBody UserNotificationRequest request);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
@@ -1,8 +1,15 @@
 package com.goormthon.backend.mindwalk.domain.user.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
+import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNicknameRequest;
+import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNotificationRequest;
+import com.goormthon.backend.mindwalk.domain.user.dto.response.UserInfoResponse;
+import com.goormthon.backend.mindwalk.global.exception.BaseException;
+import com.goormthon.backend.mindwalk.global.exception.BaseResponseStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +18,28 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+
+	@Transactional
+	public void assignNickname(Long currentUserId, UserNicknameRequest request) {
+		User user = findUserById(currentUserId);
+		user.updateNickname(request.nickname());
+	}
+
+	@Transactional(readOnly = true)
+	public UserInfoResponse getUserInfo(Long currentUserId) {
+		User user = findUserById(currentUserId);
+		return UserInfoResponse.from(user);
+	}
+
+	@Transactional
+	public void updateUser(Long currentUserId, UserNotificationRequest request) {
+		User user = findUserById(currentUserId);
+		// TODO: 알림 설정 업데이트 로직 구현
+		// user.updateNorification(request.allow_push_notification());
+	}
+
+	private User findUserById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/request/UserNicknameRequest.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/request/UserNicknameRequest.java
@@ -1,0 +1,6 @@
+package com.goormthon.backend.mindwalk.domain.user.dto.request;
+
+public record UserNicknameRequest(
+	String nickname
+) {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/request/UserNotificationRequest.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/request/UserNotificationRequest.java
@@ -1,0 +1,6 @@
+package com.goormthon.backend.mindwalk.domain.user.dto.request;
+
+public record UserNotificationRequest(
+	boolean allowPushNotification
+) {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,13 @@
+package com.goormthon.backend.mindwalk.domain.user.dto.response;
+
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
+
+public record UserInfoResponse(
+	Long userId,
+	String nickname
+	// boolean allowPushNotification
+) {
+	public static UserInfoResponse from(User user) {
+		return new UserInfoResponse(user.getId(), user.getNickname());
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/global/config/web/WebConfig.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/global/config/web/WebConfig.java
@@ -1,11 +1,22 @@
 package com.goormthon.backend.mindwalk.global.config.web;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.goormthon.backend.mindwalk.domain.auth.presentation.AuthenticatedIdResolver;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final AuthenticatedIdResolver authenticatedIdResolver;
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
@@ -13,5 +24,10 @@ public class WebConfig implements WebMvcConfigurer {
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 			.allowedHeaders("*")
 			.allowCredentials(true);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(authenticatedIdResolver);
 	}
 }


### PR DESCRIPTION
## 📣 Related Issue
- close #11

## 📝 Summary

#### 1.`@AuthenticatedId` 어노테이션 및 Resolver
- `@AuthenticatedId`를 통해 `AccessToken` 파싱하여 인증된 사용자 ID 자동 주입
- `AuthenticatedIdResolver` 구현하고 `WebConfig`에 등록하여 이 기능 활성화

#### 2. 사용자 정보 API
- 회원 닉네임 등록/수정
- 회원 정보 조회

## 🙏PR point


## 📬 Reference