### PR TITLE
[Feat] 내 마음 정원 조회

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/AuthService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/auth/application/AuthService.java
@@ -5,6 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goormthon.backend.mindwalk.domain.auth.dto.AuthRequest;
 import com.goormthon.backend.mindwalk.domain.auth.dto.AuthResponse;
+import com.goormthon.backend.mindwalk.domain.garden.dao.GardenRepository;
+import com.goormthon.backend.mindwalk.domain.garden.domain.Garden;
+import com.goormthon.backend.mindwalk.domain.garden.domain.GardenPlant;
 import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
 import com.goormthon.backend.mindwalk.domain.user.domain.User;
 
@@ -16,6 +19,7 @@ public class AuthService {
 
 	private final JwtProvider jwtProvider;
 	private final UserRepository userRepository;
+	private final GardenRepository gardenRepository;
 
 	@Transactional
 	public AuthResponse login(AuthRequest request) {
@@ -26,10 +30,13 @@ public class AuthService {
 	private User findOrCreateUser(Long oauthId) {
 		return userRepository.findByOauthId(oauthId)
 			.orElseGet(() -> {
-				User newUser = User.builder()
-					.oauthId(oauthId)
-					.build();
-				return userRepository.save(newUser);
+				User newUser = User.createUser(oauthId);
+				userRepository.save(newUser);
+				Garden newGarden = Garden.createGarden(newUser);
+				GardenPlant newPlant = GardenPlant.createGardenPlant(newGarden);
+				newGarden.getGardenPlants().add(newPlant);
+				gardenRepository.save(newGarden);
+				return newUser;
 			});
 	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/GardenController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/GardenController.java
@@ -1,10 +1,14 @@
 package com.goormthon.backend.mindwalk.domain.garden.api;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
 import com.goormthon.backend.mindwalk.domain.garden.api.docs.GardenControllerDocs;
 import com.goormthon.backend.mindwalk.domain.garden.application.GardenService;
+import com.goormthon.backend.mindwalk.domain.garden.dto.response.GetGardenInfoResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,4 +18,9 @@ import lombok.RequiredArgsConstructor;
 public class GardenController implements GardenControllerDocs {
 
 	private final GardenService gardenService;
+
+	@GetMapping
+	public BaseResponse<GetGardenInfoResponse> getUserGarden(@AuthenticatedId Long currentUserId) {
+		return BaseResponse.success(gardenService.getUserGarden(currentUserId));
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
@@ -1,7 +1,27 @@
 package com.goormthon.backend.mindwalk.domain.garden.api.docs;
 
+import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
+import com.goormthon.backend.mindwalk.domain.garden.dto.response.GetGardenInfoResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "[5. 마음 정원]", description = "마음 정원 관련 API")
 public interface GardenControllerDocs {
+
+	@Operation(summary = "내 마음 정원 조회", description = "내 마음 정원을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공",
+			content = @Content(schema = @Schema(implementation = GetGardenInfoResponse.class))
+		)
+	})
+	BaseResponse<GetGardenInfoResponse> getUserGarden(
+		@Parameter(hidden = true) @AuthenticatedId Long memberId
+	);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/application/GardenService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/application/GardenService.java
@@ -1,8 +1,20 @@
 package com.goormthon.backend.mindwalk.domain.garden.application;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.goormthon.backend.mindwalk.domain.garden.dao.GardenRepository;
+import com.goormthon.backend.mindwalk.domain.garden.domain.Garden;
+import com.goormthon.backend.mindwalk.domain.garden.domain.GardenPlant;
+import com.goormthon.backend.mindwalk.domain.garden.domain.PlantStage;
+import com.goormthon.backend.mindwalk.domain.garden.dto.response.GetGardenInfoResponse;
+import com.goormthon.backend.mindwalk.domain.garden.dto.response.GetGardenInfoResponse.TodayGrowth;
+import com.goormthon.backend.mindwalk.domain.garden.dto.response.GetGardenInfoResponse.UserFlower;
+import com.goormthon.backend.mindwalk.domain.garden.dto.response.GetGardenInfoResponse.UserGardenPlant;
+import com.goormthon.backend.mindwalk.global.exception.BaseException;
+import com.goormthon.backend.mindwalk.global.exception.BaseResponseStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +23,33 @@ import lombok.RequiredArgsConstructor;
 public class GardenService {
 
 	private final GardenRepository gardenRepository;
+
+	@Transactional(readOnly = true)
+	public GetGardenInfoResponse getUserGarden(Long userId) {
+		Garden garden = gardenRepository.findByUserId(userId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_GARDEN));
+		List<GardenPlant> gardenPlants = garden.getGardenPlants();
+		TodayGrowth todayGrowth = createTodayGrowth(gardenPlants);
+		List<UserGardenPlant> userGardenPlants = createUserGardenPlants(gardenPlants);
+		List<UserFlower> flowerCollection = createFlowerCollection(gardenPlants);
+		return new GetGardenInfoResponse(todayGrowth, userGardenPlants, flowerCollection);
+	}
+
+	// TODO: 요구사항 확인 후 작업 예정
+	private TodayGrowth createTodayGrowth(List<GardenPlant> gardenPlants) {
+		return null;
+	}
+
+	private List<UserGardenPlant> createUserGardenPlants(List<GardenPlant> gardenPlants) {
+		return gardenPlants.stream()
+			.map(UserGardenPlant::from)
+			.toList();
+	}
+
+	private List<UserFlower> createFlowerCollection(List<GardenPlant> gardenPlants) {
+		return gardenPlants.stream()
+			.filter(gardenPlant -> gardenPlant.getPlantStage() == PlantStage.FLOWER)
+			.map(UserFlower::from)
+			.toList();
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenPlantRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenPlantRepository.java
@@ -1,0 +1,10 @@
+package com.goormthon.backend.mindwalk.domain.garden.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goormthon.backend.mindwalk.domain.garden.domain.GardenPlant;
+
+@Repository
+public interface GardenPlantRepository extends JpaRepository<GardenPlant, Long> {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenRepository.java
@@ -1,5 +1,7 @@
 package com.goormthon.backend.mindwalk.domain.garden.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.goormthon.backend.mindwalk.domain.garden.domain.Garden;
 
 @Repository
 public interface GardenRepository extends JpaRepository<Garden, Long> {
+	Optional<Garden> findByUserId(Long userId);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/FlowerType.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/FlowerType.java
@@ -1,8 +1,15 @@
 package com.goormthon.backend.mindwalk.domain.garden.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum FlowerType {
-	ROSE,
-	SUNFLOWER,
-	LILY,
-	LAVENDER
+	ROSE("장미"),
+	SUNFLOWER("해바라기"),
+	LILY("백합"),
+	LAVENDER("라벤더");
+
+	private final String value;
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/Garden.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/Garden.java
@@ -1,8 +1,12 @@
 package com.goormthon.backend.mindwalk.domain.garden.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.goormthon.backend.mindwalk.domain.common.BaseTimeEntity;
 import com.goormthon.backend.mindwalk.domain.user.domain.User;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,9 +14,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +36,18 @@ public class Garden extends BaseTimeEntity {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
+
+	@Builder
+	public Garden(User user) {
+		this.user = user;
+	}
+
+	@OneToMany(mappedBy = "garden", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<GardenPlant> gardenPlants = new ArrayList<>();
+
+	public static Garden createGarden(User user) {
+		return Garden.builder()
+			.user(user)
+			.build();
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +34,9 @@ public class GardenPlant {
 	@Column(name = "growth_point", nullable = false)
 	private Long growthPoint;
 
+	@Column(name = "growth_level", nullable = false)
+	private Long growthLevel;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "flower_type", nullable = false)
 	private FlowerType flowerType;
@@ -40,4 +44,24 @@ public class GardenPlant {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "garden_id")
 	private Garden garden;
+
+	@Builder
+	public GardenPlant(PlantStage plantStage, Long growthPoint, Long growthLevel, FlowerType flowerType,
+		Garden garden) {
+		this.plantStage = plantStage;
+		this.growthPoint = growthPoint;
+		this.growthLevel = growthLevel;
+		this.flowerType = flowerType;
+		this.garden = garden;
+	}
+
+	public static GardenPlant createGardenPlant(Garden garden) {
+		return GardenPlant.builder()
+			.plantStage(PlantStage.SEED)
+			.growthPoint(0L)
+			.growthLevel(0L)
+			.flowerType(FlowerType.ROSE)
+			.garden(garden)
+			.build();
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/PlantStage.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/PlantStage.java
@@ -1,7 +1,14 @@
 package com.goormthon.backend.mindwalk.domain.garden.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum PlantStage {
-	SEED,
-	SPROUT,
-	FLOWER
+	SEED("씨앗"),
+	SPROUT("새싹"),
+	FLOWER("꽃");
+
+	private final String value;
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dto/response/GetGardenInfoResponse.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dto/response/GetGardenInfoResponse.java
@@ -1,0 +1,56 @@
+package com.goormthon.backend.mindwalk.domain.garden.dto.response;
+
+import java.util.List;
+
+import com.goormthon.backend.mindwalk.domain.garden.domain.GardenPlant;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetGardenInfoResponse(
+	TodayGrowth todayGrowth,
+	List<UserGardenPlant> gardenPlants,
+	List<UserFlower> flowerCollection
+) {
+	public record TodayGrowth(
+		@Schema(description = "오늘 하루 성장 포인트", example = "10")
+		Long todayGrowthPoint,
+		@Schema(description = "오늘 하루 성장 레벨", example = "1")
+		Long todayGrowthLevel,
+		@Schema(description = "현재 식물 성장 단계", example = "씨앗")
+		String plantStage,
+		@Schema(description = "꽃 종류", example = "장미")
+		String flowerType
+	) {
+	}
+
+	public record UserGardenPlant(
+		@Schema(description = "정원 식물 ID", example = "1")
+		Long gardenPlantId,
+		@Schema(description = "식물 성장 단계", example = "씨앗")
+		String plantStage,
+		@Schema(description = "식물 종류", example = "장미")
+		String flowerType
+	) {
+		public static UserGardenPlant from(GardenPlant gardenPlant) {
+			return new UserGardenPlant(
+				gardenPlant.getId(),
+				gardenPlant.getPlantStage().getValue(),
+				gardenPlant.getFlowerType().getValue()
+			);
+		}
+	}
+
+	public record UserFlower(
+		@Schema(description = "수집한 꽃 ID", example = "2")
+		Long gardenPlantId,
+		@Schema(description = "꽃 종류", example = "해바라기")
+		String flowerType
+	) {
+		public static UserFlower from(GardenPlant gardenPlant) {
+			return new UserFlower(
+				gardenPlant.getId(),
+				gardenPlant.getFlowerType().getValue()
+			);
+		}
+	}
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
@@ -40,6 +40,6 @@ public class UserService {
 
 	private User findUserById(Long userId) {
 		return userRepository.findById(userId)
-			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
 	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/domain/User.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/domain/User.java
@@ -37,6 +37,12 @@ public class User extends BaseTimeEntity {
 		this.oauthId = oauthId;
 	}
 
+	public static User createUser(Long oauthId) {
+		return User.builder()
+			.oauthId(oauthId)
+			.build();
+	}
+
 	public void updateNickname(String nickname) {
 		this.nickname = nickname;
 	}

--- a/src/main/java/com/goormthon/backend/mindwalk/global/exception/BaseResponseStatus.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/global/exception/BaseResponseStatus.java
@@ -39,6 +39,8 @@ public enum BaseResponseStatus {
 	 * 404 NOT_FOUND 잘못된 리소스 접근
 	 */
 	NOT_FOUND(false, 404, HttpStatus.NOT_FOUND, "Not Found"),
+	NOT_FOUND_USER(false, 40401, HttpStatus.NOT_FOUND, "User를 찾을 수 없습니다."),
+	NOT_FOUND_GARDEN(false, 40402, HttpStatus.NOT_FOUND, "Garden을 찾을 수 없습니다."),
 
 	/**
 	 * 405 METHOD_NOT_ALLOWED 지원하지 않은 method 호출


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #16 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

#### 1. 내 마음 정원 조회 API 구현 (`GET /api/gardens`)
- 사용자가 자신의 정원 정보를 조회할 수 있는 API
- 오늘의 성장, 현재 정원에 있는 식물 목록, 지금까지 수집한 꽃 목록이 포함됨

#### 2. 신규 사용자 회원가입 시 정원 자동 생성
- `AuthService`의 `findOrCreateUser` 로직 수정
    - 새로운 사용자가 생성될 때 해당 유저와 연결된 `Garden`, `GardenPlant` 엔티티가 자동으로 생성되도록 수정
- 정원이 생성될 때, 기본 식물(장미 씨앗)이 하나 생성됨
    - 랜덤 식물 기능은 추후에 구현할 예정 

#### 3. 도메인 모델링 개선 및 리팩토링
- 양방향 연관관계 설정
    - `Garden`과 `GardenPlant` 사이에 양방향 연관관계를 설정
- 팩토리 메서드 도입
    - `User`, `Garden`, `GardenPlant` 엔티티에 정적 팩토리 메서드(`createUser`, `createGarden` 등)를 도입
- 예외 처리 세분화
    - 기존의 범용적인 `NOT_FOUND` 예외를 `NOT_FOUND_USER`, `NOT_FOUND_GARDEN`으로 세분화

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
`todayGrowth` 부분은 현재 임시로 null을 반환
- 정확한 요구사항을 다시 확인한 후 구현할 예정

회원가입 시 기본 식물은 현재 '장미 씨앗'으로 고정 
- 랜덤 식물로 생성되도록 구현 예정

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->