### PR TITLE
[Feat] 산책 미션 완료 처리

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
@@ -34,9 +34,6 @@ public class GardenPlant {
 	@Column(name = "growth_point", nullable = false)
 	private Long growthPoint;
 
-	@Column(name = "growth_level", nullable = false)
-	private Long growthLevel;
-
 	@Enumerated(EnumType.STRING)
 	@Column(name = "flower_type", nullable = false)
 	private FlowerType flowerType;
@@ -46,11 +43,9 @@ public class GardenPlant {
 	private Garden garden;
 
 	@Builder
-	public GardenPlant(PlantStage plantStage, Long growthPoint, Long growthLevel, FlowerType flowerType,
-		Garden garden) {
+	public GardenPlant(PlantStage plantStage, Long growthPoint, FlowerType flowerType, Garden garden) {
 		this.plantStage = plantStage;
 		this.growthPoint = growthPoint;
-		this.growthLevel = growthLevel;
 		this.flowerType = flowerType;
 		this.garden = garden;
 	}
@@ -59,9 +54,17 @@ public class GardenPlant {
 		return GardenPlant.builder()
 			.plantStage(PlantStage.SEED)
 			.growthPoint(0L)
-			.growthLevel(0L)
 			.flowerType(FlowerType.ROSE)
 			.garden(garden)
 			.build();
+	}
+
+	public void addGrowthPoint(Long point) {
+		this.growthPoint += point;
+		if (this.growthPoint >= 150) {
+			this.plantStage = PlantStage.FLOWER;
+		} else if (this.growthPoint >= 50) {
+			this.plantStage = PlantStage.SPROUT;
+		}
 	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dto/response/GetGardenInfoResponse.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dto/response/GetGardenInfoResponse.java
@@ -14,8 +14,6 @@ public record GetGardenInfoResponse(
 	public record TodayGrowth(
 		@Schema(description = "오늘 하루 성장 포인트", example = "10")
 		Long todayGrowthPoint,
-		@Schema(description = "오늘 하루 성장 레벨", example = "1")
-		Long todayGrowthLevel,
 		@Schema(description = "현재 식물 성장 단계", example = "씨앗")
 		String plantStage,
 		@Schema(description = "꽃 종류", example = "장미")

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/WalkMissionController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/WalkMissionController.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
 import com.goormthon.backend.mindwalk.domain.walkmission.api.docs.WalkMissionControllerDocs;
 import com.goormthon.backend.mindwalk.domain.walkmission.application.WalkMissionService;
-import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.WalkMissionCreateRequest;
+import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.CompleteWalkMissionRequest;
+import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.CreateWalkMissionRequest;
 import com.goormthon.backend.mindwalk.domain.walkmission.dto.response.WalkMissionListResponse;
 import com.goormthon.backend.mindwalk.global.response.BaseResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -23,9 +25,8 @@ public class WalkMissionController implements WalkMissionControllerDocs {
 	private final WalkMissionService walkMissionService;
 
 	@PostMapping
-	public BaseResponse<WalkMissionListResponse> createWalkMission(
-		@AuthenticatedId Long currentUserId,
-		@RequestBody WalkMissionCreateRequest request) {
+	public BaseResponse<WalkMissionListResponse> createWalkMission(@AuthenticatedId Long currentUserId,
+		@Valid @RequestBody CreateWalkMissionRequest request) {
 		return BaseResponse.success(walkMissionService.createWalkMission(currentUserId, request));
 	}
 
@@ -33,6 +34,14 @@ public class WalkMissionController implements WalkMissionControllerDocs {
 	public BaseResponse<Void> cancelWalkMission(@AuthenticatedId Long currentUserId,
 		@PathVariable(value = "missionId") Long missionId) {
 		walkMissionService.cancelWalkMission(currentUserId, missionId);
+		return BaseResponse.success();
+	}
+
+	@PostMapping("/{missionId}/complete")
+	public BaseResponse<Void> completeWalkMission(@AuthenticatedId Long currentUserId,
+		@PathVariable(value = "missionId") Long missionId,
+		@RequestBody CompleteWalkMissionRequest request) {
+		walkMissionService.completeWalkMission(currentUserId, missionId, request);
 		return BaseResponse.success();
 	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/docs/WalkMissionControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/docs/WalkMissionControllerDocs.java
@@ -4,13 +4,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
-import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.WalkMissionCreateRequest;
+import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.CompleteWalkMissionRequest;
+import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.CreateWalkMissionRequest;
 import com.goormthon.backend.mindwalk.domain.walkmission.dto.response.WalkMissionListResponse;
 import com.goormthon.backend.mindwalk.global.response.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -37,7 +37,8 @@ public interface WalkMissionControllerDocs {
 	})
 	public BaseResponse<WalkMissionListResponse> createWalkMission(
 		@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
-		@Valid @RequestBody WalkMissionCreateRequest request);
+		@Valid @RequestBody CreateWalkMissionRequest request
+	);
 
 	@Operation(
 		summary = "산책 미션 취소",
@@ -54,6 +55,21 @@ public interface WalkMissionControllerDocs {
 		@ApiResponse(responseCode = "404", description = "존재하지 않는 산책 미션인 경우",
 			content = @Content(schema = @Schema(implementation = BaseResponse.class)))
 	})
-	public BaseResponse<Void> cancelWalkMission(@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
-		@PathVariable(value = "missionId") Long missionId);
+	public BaseResponse<Void> cancelWalkMission(
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
+		@PathVariable(value = "missionId") Long missionId
+	);
+
+	@Operation(
+		summary = "산책 미션 완료",
+		description = "진행 중인 산책 미션을 완료 처리합니다. 미션 완료 시 식물 성장 포인트가 10 상승합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "산책 미션 완료 성공")
+	})
+	public BaseResponse<Void> completeWalkMission(
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
+		@Parameter(description = "산책 미션 ID") @PathVariable(value = "missionId") Long missionId,
+		@Valid @RequestBody CompleteWalkMissionRequest request
+	);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/application/WalkMissionService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/application/WalkMissionService.java
@@ -6,12 +6,16 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormthon.backend.mindwalk.domain.garden.dao.GardenRepository;
+import com.goormthon.backend.mindwalk.domain.garden.domain.Garden;
+import com.goormthon.backend.mindwalk.domain.garden.domain.GardenPlant;
+import com.goormthon.backend.mindwalk.domain.garden.domain.PlantStage;
 import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
 import com.goormthon.backend.mindwalk.domain.user.domain.User;
 import com.goormthon.backend.mindwalk.domain.walkmission.dao.WalkMissionRepository;
 import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMission;
-import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMissionStatus;
-import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.WalkMissionCreateRequest;
+import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.CompleteWalkMissionRequest;
+import com.goormthon.backend.mindwalk.domain.walkmission.dto.request.CreateWalkMissionRequest;
 import com.goormthon.backend.mindwalk.domain.walkmission.dto.response.WalkMissionListResponse;
 import com.goormthon.backend.mindwalk.domain.walkmission.healingcontent.dao.HealingContentRepository;
 import com.goormthon.backend.mindwalk.domain.walkmission.healingcontent.dao.WalkMissionHealingContentRepository;
@@ -30,35 +34,25 @@ public class WalkMissionService {
 	private final WalkMissionRepository walkMissionRepository;
 	private final HealingContentRepository healingContentRepository;
 	private final WalkMissionHealingContentRepository walkMissionHealingContentRepository;
+	private final GardenRepository gardenRepository;
 
 	@Transactional
-	public WalkMissionListResponse createWalkMission(Long currentUserId, WalkMissionCreateRequest request) {
+	public WalkMissionListResponse createWalkMission(Long currentUserId, CreateWalkMissionRequest request) {
 		User user = findUserById(currentUserId);
-
-		WalkMission walkMission = WalkMission.builder()
-			.targetDurationMinutes(request.targetDurationMinutes())
-			.status(WalkMissionStatus.IN_PROGRESS)
-			.user(user)
-			.build();
+		WalkMission walkMission = WalkMission.createWalkMission(user, request.targetDurationMinutes());
 		walkMissionRepository.save(walkMission);
-
 		List<HealingContent> healingContents = healingContentRepository.findByCategoryIn(request.healingContents());
-
 		if (healingContents.isEmpty()) {
 			throw new BaseException(BaseResponseStatus.NOT_FOUND_HEALING_CONTENT);
 		}
-
 		Collections.shuffle(healingContents);
-
 		List<WalkMissionHealingContent> walkMissionHealingContents = healingContents.stream().map(healingContent ->
 			WalkMissionHealingContent.builder()
 				.walkMission(walkMission)
 				.healingContent(healingContent)
 				.build()
 		).toList();
-
 		walkMissionHealingContentRepository.saveAll(walkMissionHealingContents);
-
 		return WalkMissionListResponse.from(walkMission, healingContents);
 	}
 
@@ -66,17 +60,33 @@ public class WalkMissionService {
 	public void cancelWalkMission(Long currentUserId, Long missionId) {
 		User user = findUserById(currentUserId);
 		WalkMission walkMission = walkMissionRepository.findById(missionId)
-			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_MISSION));
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_WALK_MISSION));
 		if (!walkMission.getUser().getId().equals(user.getId())) {
 			throw new BaseException(BaseResponseStatus.FORBIDDEN);
 		}
-
 		walkMission.cancel();
 	}
 
 	private User findUserById(Long userId) {
 		return userRepository.findById(userId)
-			// TODO: NOT_FOUND_USER로 변경
-			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+	}
+
+	@Transactional
+	public void completeWalkMission(Long userId, Long missionId, CompleteWalkMissionRequest request) {
+		User user = findUserById(userId);
+		WalkMission walkMission = walkMissionRepository.findById(missionId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_WALK_MISSION));
+		if (!walkMission.getUser().getId().equals(user.getId())) {
+			throw new BaseException(BaseResponseStatus.FORBIDDEN);
+		}
+		walkMission.complete(request.steps(), request.distanceMeters(), request.actualDurationMinutes());
+		Garden garden = gardenRepository.findByUserId(userId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_GARDEN));
+		GardenPlant growingPlant = garden.getGardenPlants().stream()
+			.filter(plant -> plant.getPlantStage() != PlantStage.FLOWER)
+			.findFirst()
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_GROWING_PLANT));
+		growingPlant.addGrowthPoint(10L);
 	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMission.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMission.java
@@ -62,10 +62,30 @@ public class WalkMission extends BaseTimeEntity {
 		this.user = user;
 	}
 
+	public static WalkMission createWalkMission(User user, Long targetDurationMinutes) {
+		return WalkMission.builder()
+			.targetDurationMinutes(targetDurationMinutes)
+			.status(WalkMissionStatus.IN_PROGRESS)
+			.user(user)
+			.build();
+	}
+
 	public void cancel() {
-		if (this.status != WalkMissionStatus.IN_PROGRESS) {
-			throw new BaseException(BaseResponseStatus.CANNOT_CANCEL_MISSION);
-		}
+		validateProcessable();
 		this.status = WalkMissionStatus.CANCELED;
+	}
+
+	public void complete(Long steps, Long distanceMeters, Long actualDurationMinutes) {
+		validateProcessable();
+		this.steps = steps;
+		this.distanceMeters = distanceMeters;
+		this.actualDurationMinutes = actualDurationMinutes;
+		this.status = WalkMissionStatus.COMPLETED;
+	}
+
+	private void validateProcessable() {
+		if (this.status != WalkMissionStatus.IN_PROGRESS) {
+			throw new BaseException(BaseResponseStatus.INVALID_MISSION_STATUS);
+		}
 	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dto/request/CompleteWalkMissionRequest.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dto/request/CompleteWalkMissionRequest.java
@@ -1,0 +1,13 @@
+package com.goormthon.backend.mindwalk.domain.walkmission.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CompleteWalkMissionRequest(
+	@Schema(description = "총 걸음 수", example = "800")
+	Long steps,
+	@Schema(description = "총 산책 이동 거리(미터 단위)", example = "1900")
+	Long distanceMeters,
+	@Schema(description = "총 산책 소요 시간(분 단위)", example = "17")
+	Long actualDurationMinutes
+) {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dto/request/CreateWalkMissionRequest.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dto/request/CreateWalkMissionRequest.java
@@ -7,7 +7,7 @@ import com.goormthon.backend.mindwalk.domain.walkmission.healingcontent.domain.C
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
-public record WalkMissionCreateRequest(
+public record CreateWalkMissionRequest(
 	Long targetDurationMinutes,
 	@NotEmpty(message = "힐링 컨텐츠는 비어있을 수 없습니다.")
 	@Size(min = 1, max = 3, message = "힐링 컨텐츠는 1개에서 3개까지 선택할 수 있습니다.")

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/healingcontent/dao/HealingContentRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/healingcontent/dao/HealingContentRepository.java
@@ -10,6 +10,5 @@ import com.goormthon.backend.mindwalk.domain.walkmission.healingcontent.domain.H
 
 @Repository
 public interface HealingContentRepository extends JpaRepository<HealingContent, Long> {
-
 	List<HealingContent> findByCategoryIn(List<Category> categories);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/global/exception/BaseResponseStatus.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/global/exception/BaseResponseStatus.java
@@ -24,7 +24,7 @@ public enum BaseResponseStatus {
 	REQ_BINDING_FAIL(false, 40004, HttpStatus.BAD_REQUEST, "잘못된 request 입니다."),
 	FAILED_VALIDATION(false, 40005, HttpStatus.BAD_REQUEST, "입력값이 누락되었거나, 부적절한 입력 값이 있습니다."),
 	MISMATCH_PARAM_TYPE(false, 40006, HttpStatus.BAD_REQUEST, "잘못된 파라미터 타입입니다."),
-	CANNOT_CANCEL_MISSION(false, 40007, HttpStatus.BAD_REQUEST, "이미 완료되었거나 취소된 미션은 취소할 수 없습니다."),
+	INVALID_MISSION_STATUS(false, 40007, HttpStatus.BAD_REQUEST, "미션이 진행중인 상태가 아닙니다."),
 
 	/**
 	 * 401 UNAUTHORIZED 권한없음(인증 실패)
@@ -40,11 +40,11 @@ public enum BaseResponseStatus {
 	 * 404 NOT_FOUND 잘못된 리소스 접근
 	 */
 	NOT_FOUND(false, 404, HttpStatus.NOT_FOUND, "Not Found"),
-	NOT_FOUND_MISSION(false, 404, HttpStatus.NOT_FOUND, "Not Found Mission"),
-	NOT_FOUND_HEALING_CONTENT(false, 404, HttpStatus.NOT_FOUND, "Not Found HealingContent"),
 	NOT_FOUND_USER(false, 40401, HttpStatus.NOT_FOUND, "User를 찾을 수 없습니다."),
-	NOT_FOUND_GARDEN(false, 40402, HttpStatus.NOT_FOUND, "Garden을 찾을 수 없습니다."),
-	NOT_FOUND_GROWING_PLANT(false, 40403, HttpStatus.NOT_FOUND, "현재 키우고 있는 식물을 찾을 수 없습니다."),
+	NOT_FOUND_WALK_MISSION(false, 40402, HttpStatus.NOT_FOUND, "WalkMission을 찾을 수 없습니다."),
+	NOT_FOUND_HEALING_CONTENT(false, 40403, HttpStatus.NOT_FOUND, "HealingContent를 찾을 수 없습니다."),
+	NOT_FOUND_GARDEN(false, 40404, HttpStatus.NOT_FOUND, "Garden을 찾을 수 없습니다."),
+	NOT_FOUND_GROWING_PLANT(false, 40405, HttpStatus.NOT_FOUND, "현재 키우고 있는 식물을 찾을 수 없습니다."),
 
 	/**
 	 * 405 METHOD_NOT_ALLOWED 지원하지 않은 method 호출


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #23 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->


#### 1. 산책 미션 완료 처리 기능 구현
- 미션 완료 시 사용자의 걸음 수, 이동 거리, 실제 소요 시간 저장
- 미션이 `IN_PROGRESS` 상태일 때만 완료할 수 있도록 유효성 검사 추가
- 미션 완료 시, 사용자가 현재 키우고 있는 식물 성장 포인트(10점)를 지급

#### 2. 식물 성장 로직 리팩토링
- `GardenPlant` 엔티티에서 불필요한 `growthLevel` 필드를 제거
    - `growthPoint`를 기준으로 성장
- `addGrowthPoint` 메서드를 추가하여 성장 포인트가 누적됨에 따라 식물의 단계(`plantStage`)가 씨앗, 새싹, 꽃으로 자동 변경되도록 구현
- `GetGardenInfoResponse` DTO에서 `todayGrowthLevel` 필드 제거


#### 3. 코드 리팩토링 및 개선
- DTO 이름 변경
    - `WalkMissionCreateRequest`를 `CreateWalkMissionRequest`로 수정
- 정적 팩토리 메서드 적용
    - `WalkMission` 엔티티 생성을 빌더 패턴 대신 정적 팩토리 메서드(`createWalkMission`)로 수정
- 예외 처리 개선
    - `BaseResponseStatus`의 미션 상태 관련 예외를 `INVALID_MISSION_STATUS`로 통합

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->