### PR TITLE
[Feat] 주간 요약 조회

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
@@ -23,7 +23,7 @@ public interface GardenControllerDocs {
 		)
 	})
 	BaseResponse<GetGardenInfoResponse> getUserGarden(
-		@Parameter(hidden = true) @AuthenticatedId Long memberId
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId
 	);
 
 	@Operation(summary = "사용자가 현재 키우고 있는 식물 조회", description = "사용자가 현재 키우고 있는 식물의 정보를 조회합니다.")
@@ -33,6 +33,6 @@ public interface GardenControllerDocs {
 		)
 	})
 	BaseResponse<GetGrowingPlantInfoResponse> getUserGrowingPlant(
-		@Parameter(hidden = true) @AuthenticatedId Long memberId
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId
 	);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/ReportController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/ReportController.java
@@ -1,10 +1,14 @@
 package com.goormthon.backend.mindwalk.domain.report.api;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
 import com.goormthon.backend.mindwalk.domain.report.api.docs.ReportControllerDocs;
 import com.goormthon.backend.mindwalk.domain.report.application.ReportService;
+import com.goormthon.backend.mindwalk.domain.report.dto.response.GetWeeklySummaryResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,4 +18,9 @@ import lombok.RequiredArgsConstructor;
 public class ReportController implements ReportControllerDocs {
 
 	private final ReportService reportService;
+
+	@GetMapping("/weekly-summary")
+	public BaseResponse<GetWeeklySummaryResponse> getWeeklySummary(@AuthenticatedId Long currentUserId) {
+		return BaseResponse.success(reportService.getWeeklySummary(currentUserId));
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/docs/ReportControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/docs/ReportControllerDocs.java
@@ -1,7 +1,30 @@
 package com.goormthon.backend.mindwalk.domain.report.api.docs;
 
+import com.goormthon.backend.mindwalk.domain.auth.presentation.annotation.AuthenticatedId;
+import com.goormthon.backend.mindwalk.domain.report.dto.response.GetWeeklySummaryResponse;
+import com.goormthon.backend.mindwalk.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "[6. 주간 요약]", description = "주간 요약 관련 API")
+@Tag(name = "[6. 주간 요약", description = "주간 요약 관련 API")
 public interface ReportControllerDocs {
+
+	@Operation(
+		summary = "주간 요약 조회",
+		description = "이번 주 산책 요약 정보를 조회합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공",
+			content = @Content(schema = @Schema(implementation = GetWeeklySummaryResponse.class))
+		)
+	})
+	BaseResponse<GetWeeklySummaryResponse> getWeeklySummary(
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId
+	);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/application/ReportService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/application/ReportService.java
@@ -1,10 +1,63 @@
 package com.goormthon.backend.mindwalk.domain.report.application;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormthon.backend.mindwalk.domain.report.dto.response.GetWeeklySummaryResponse;
+import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
+import com.goormthon.backend.mindwalk.domain.walkmission.dao.WalkMissionRepository;
+import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMission;
+import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMissionStatus;
+import com.goormthon.backend.mindwalk.global.exception.BaseException;
+import com.goormthon.backend.mindwalk.global.exception.BaseResponseStatus;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ReportService {
+
+	private final WalkMissionRepository walkMissionRepository;
+	private final UserRepository userRepository;
+
+	@Transactional(readOnly = true)
+	public GetWeeklySummaryResponse getWeeklySummary(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+		boolean yesterdayWalkSuccess = checkYesterdayWalkSuccess(user);
+		List<WalkMission> weeklyMissions = getWeeklyCompletedMissions(user);
+		long weeklyWalkCount = weeklyMissions.size();
+		long weeklyDistanceMeters = weeklyMissions.stream()
+			.mapToLong(WalkMission::getDistanceMeters)
+			.sum();
+		long weeklyDurationMinutes = weeklyMissions.stream()
+			.mapToLong(WalkMission::getActualDurationMinutes)
+			.sum();
+		return new GetWeeklySummaryResponse(yesterdayWalkSuccess, weeklyWalkCount, weeklyDistanceMeters,
+			weeklyDurationMinutes);
+	}
+
+	private boolean checkYesterdayWalkSuccess(User user) {
+		LocalDate yesterday = LocalDate.now().minusDays(1);
+		LocalDateTime startOfYesterday = yesterday.atStartOfDay();
+		LocalDateTime endOfYesterday = yesterday.atTime(LocalTime.MAX);
+		return walkMissionRepository.existsByUserAndStatusAndCompletedAtBetween(user,
+			WalkMissionStatus.COMPLETED, startOfYesterday, endOfYesterday);
+	}
+
+	private List<WalkMission> getWeeklyCompletedMissions(User user) {
+		LocalDate today = LocalDate.now();
+		LocalDate startOfWeek = today.with(DayOfWeek.MONDAY);
+		LocalDateTime startOfWeekTime = startOfWeek.atStartOfDay();
+		LocalDateTime endOfWeekTime = today.atTime(LocalTime.MAX);
+		return walkMissionRepository.findAllByUserAndStatusAndCompletedAtBetween(user,
+			WalkMissionStatus.COMPLETED, startOfWeekTime, endOfWeekTime);
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/dto/response/GetWeeklySummaryResponse.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/dto/response/GetWeeklySummaryResponse.java
@@ -1,0 +1,15 @@
+package com.goormthon.backend.mindwalk.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetWeeklySummaryResponse(
+	@Schema(description = "어제 산책 성공 여부", example = "true")
+	Boolean yesterdayWalkSuccess,
+	@Schema(description = "이번 주 누적 산책 횟수", example = "5")
+	Long weeklyWalkCount,
+	@Schema(description = "이번 주 누적 산책 거리 (미터)", example = "12345")
+	Long weeklyDistanceMeters,
+	@Schema(description = "이번 주 누적 산책 시간 (분)", example = "120")
+	Long weeklyDurationMinutes
+) {
+}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/docs/UserControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/api/docs/UserControllerDocs.java
@@ -32,7 +32,7 @@ public interface UserControllerDocs {
 			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
 	})
 	BaseResponse<Void> createNickname(
-		@Parameter(hidden = true) @AuthenticatedId Long userId,
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
 		@Valid @RequestBody UserNicknameRequest request
 	);
 
@@ -47,8 +47,10 @@ public interface UserControllerDocs {
 		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
 			content = @Content(schema = @Schema(implementation = BaseResponse.class))),
 	})
-	public BaseResponse<Void> updateNickname(@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
-		@RequestBody UserNicknameRequest request);
+	public BaseResponse<Void> updateNickname(
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
+		@RequestBody UserNicknameRequest request
+	);
 
 	@Operation(
 		summary = "회원 정보 조회",
@@ -63,7 +65,7 @@ public interface UserControllerDocs {
 			content = @Content(schema = @Schema(implementation = BaseResponse.class)))
 	})
 	BaseResponse<UserInfoResponse> getUserInfo(
-		@Parameter(hidden = true) @AuthenticatedId Long userId
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId
 	);
 
 	@Operation(
@@ -73,6 +75,7 @@ public interface UserControllerDocs {
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "설정 수정 성공")
 	})
-	BaseResponse<Void> updateUser(@Parameter(hidden = true) @AuthenticatedId Long userId,
+	BaseResponse<Void> updateUser(
+		@Parameter(hidden = true) @AuthenticatedId Long currentUserId,
 		@RequestBody UserNotificationRequest request);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/WalkMissionController.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/api/WalkMissionController.java
@@ -30,7 +30,7 @@ public class WalkMissionController implements WalkMissionControllerDocs {
 		return BaseResponse.success(walkMissionService.createWalkMission(currentUserId, request));
 	}
 
-	@PostMapping("/{missionId}/cancle")
+	@PostMapping("/{missionId}/cancel")
 	public BaseResponse<Void> cancelWalkMission(@AuthenticatedId Long currentUserId,
 		@PathVariable(value = "missionId") Long missionId) {
 		walkMissionService.cancelWalkMission(currentUserId, missionId);

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dao/WalkMissionRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dao/WalkMissionRepository.java
@@ -1,10 +1,20 @@
 package com.goormthon.backend.mindwalk.domain.walkmission.dao;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.goormthon.backend.mindwalk.domain.user.domain.User;
 import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMission;
+import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMissionStatus;
 
 @Repository
 public interface WalkMissionRepository extends JpaRepository<WalkMission, Long> {
+	List<WalkMission> findAllByUserAndStatusAndCompletedAtBetween(User user, WalkMissionStatus status,
+		LocalDateTime start, LocalDateTime end);
+
+	boolean existsByUserAndStatusAndCompletedAtBetween(User user, WalkMissionStatus status, LocalDateTime start,
+		LocalDateTime end);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMission.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/domain/WalkMission.java
@@ -1,5 +1,7 @@
 package com.goormthon.backend.mindwalk.domain.walkmission.domain;
 
+import java.time.LocalDateTime;
+
 import com.goormthon.backend.mindwalk.domain.common.BaseTimeEntity;
 import com.goormthon.backend.mindwalk.domain.user.domain.User;
 import com.goormthon.backend.mindwalk.global.exception.BaseException;
@@ -47,6 +49,9 @@ public class WalkMission extends BaseTimeEntity {
 	@Column(name = "target_duration_minutes", nullable = false)
 	private Long targetDurationMinutes;
 
+	@Column(name = "completed_at")
+	private LocalDateTime completedAt;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
@@ -81,6 +86,7 @@ public class WalkMission extends BaseTimeEntity {
 		this.distanceMeters = distanceMeters;
 		this.actualDurationMinutes = actualDurationMinutes;
 		this.status = WalkMissionStatus.COMPLETED;
+		this.completedAt = LocalDateTime.now();
 	}
 
 	private void validateProcessable() {

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -7,8 +7,3 @@ spring:
     url: jdbc:mysql://${DB_HOST}:3306/mindwalk_db
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-
-  sql:
-    init:
-      mode: always
-      data-locations: classpath:healing_content.sql

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,3 +10,7 @@ spring:
         show_sql: true
         format_sql: true
     defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:healing_content.sql

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "prod"
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
 
 management:
   endpoints:


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #25 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
#### 1. 주간 요약 조회 API 구현
- `getWeeklySummary()`: 어제 산책 성공 여부, 이번 주(월요일~오늘)의 누적 산책 횟수, 이동 거리, 산책 시간을 반환
    - `checkYesterdayWalkSuccess()`: 어제 산책 완료 기록을 조회
    - `getWeeklyCompletedMissions()`: 이번 주 월요일부터 오늘까지 완료된 모든 산책 미션 목록 조회

#### 2. 도메인 Entity 수정
- `WalkMission`
    - `completed_at` 필드 추가 : 산책 미션을 완료 했을때의 시간을 기록
    - 산책 미션을 완료 처리하는 `complete()` 메서드 로직 수정 : 기존 로직 + 산책을 완료한 현재 시간을 기록

#### 3. Swagger 리팩토링
- 파라미터 이름 일관성 통일
    - 다른 컨트롤러 문서에서 사용되던 파라미터 이름이 `memberId` 또는 `userId`에서 `currentUserId`로 일관성 있게 통일

#### 4. 기타 수정 및 리팩토링
- `WalkMissionController` (오타 수정)
     - 엔드포인트 오타 수정
- `application-*.yml` (설정 파일 변경)
    - `application-datasource.yml`에서 `sql.init` 관련 설정을 `application-local.yml`로 이동
        - 로컬 환경에서만 데이터 초기화 스크립트(`healing_content.sql`)가 실행되도록 수정
    - `application-prod.yml`의 ddl-auto 옵션을 create에서 validate로 수정


## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->