### PR TITLE
[Feat] 정원 식물 생성 시 꽃 종류 랜덤 배정

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/api/docs/GardenControllerDocs.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "[5. 마음 정원]", description = "마음 정원 관련 API")
+@Tag(name = "[4. 마음 정원]", description = "마음 정원 관련 API")
 public interface GardenControllerDocs {
 
 	@Operation(summary = "내 마음 정원 조회", description = "내 마음 정원을 조회합니다.")

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/FlowerType.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/FlowerType.java
@@ -1,5 +1,7 @@
 package com.goormthon.backend.mindwalk.domain.garden.domain;
 
+import java.util.Random;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +14,10 @@ public enum FlowerType {
 	LAVENDER("라벤더");
 
 	private final String value;
+	private static final Random RANDOM = new Random();
+
+	public static FlowerType getRandomFlowerType() {
+		FlowerType[] flowerTypes = values();
+		return flowerTypes[RANDOM.nextInt(flowerTypes.length)];
+	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
@@ -56,7 +56,7 @@ public class GardenPlant extends BaseTimeEntity {
 		return GardenPlant.builder()
 			.plantStage(PlantStage.SEED)
 			.growthPoint(0L)
-			.flowerType(FlowerType.ROSE)
+			.flowerType(FlowerType.getRandomFlowerType())
 			.garden(garden)
 			.build();
 	}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/notification/api/docs/NotificationApi.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/notification/api/docs/NotificationApi.java
@@ -2,6 +2,6 @@ package com.goormthon.backend.mindwalk.domain.notification.api.docs;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "[7. 알림]", description = "알림 관련 API")
+@Tag(name = "[6. 알림]", description = "알림 관련 API")
 public interface NotificationApi {
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/docs/ReportControllerDocs.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/report/api/docs/ReportControllerDocs.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "[6. 주간 요약", description = "주간 요약 관련 API")
+@Tag(name = "[5. 주간 요약]", description = "주간 요약 관련 API")
 public interface ReportControllerDocs {
 
 	@Operation(


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #29 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
#### 1. 정원 식물 생성 시 꽃 종류 랜덤 배정
- 새로운 정원 식물이 생성될 때, 고정된 종류가 아닌 다양한 꽃이 무작위로 배정되도록 수정
- `FlowerType` : `getRandomFlowerType()` 정적 메서드를 추가하여, Enum에 정의된 모든 꽃 종류(`ROSE`, `SUNFLOWER`, `LILY`, `LAVENDER`) 중 하나를 무작위로 반환하도록

#### 2. Swagger API 문서 정리
- Swagger 태그 순서 재정렬

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->