### PR TITLE
[Feat] 마이페이지 조회 API에 산책 횟수 및 피운 꽃 개수 필드 추가

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenPlantRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dao/GardenPlantRepository.java
@@ -12,4 +12,6 @@ import com.goormthon.backend.mindwalk.domain.garden.domain.PlantStage;
 @Repository
 public interface GardenPlantRepository extends JpaRepository<GardenPlant, Long> {
 	Optional<GardenPlant> findByGardenAndPlantStageNot(Garden garden, PlantStage plantStage);
+
+	Long countByGardenAndPlantStage(Garden garden, PlantStage plantStage);
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/application/UserService.java
@@ -3,11 +3,17 @@ package com.goormthon.backend.mindwalk.domain.user.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormthon.backend.mindwalk.domain.garden.dao.GardenPlantRepository;
+import com.goormthon.backend.mindwalk.domain.garden.dao.GardenRepository;
+import com.goormthon.backend.mindwalk.domain.garden.domain.Garden;
+import com.goormthon.backend.mindwalk.domain.garden.domain.PlantStage;
 import com.goormthon.backend.mindwalk.domain.user.dao.UserRepository;
 import com.goormthon.backend.mindwalk.domain.user.domain.User;
 import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNicknameRequest;
 import com.goormthon.backend.mindwalk.domain.user.dto.request.UserNotificationRequest;
 import com.goormthon.backend.mindwalk.domain.user.dto.response.UserInfoResponse;
+import com.goormthon.backend.mindwalk.domain.walkmission.dao.WalkMissionRepository;
+import com.goormthon.backend.mindwalk.domain.walkmission.domain.WalkMissionStatus;
 import com.goormthon.backend.mindwalk.global.exception.BaseException;
 import com.goormthon.backend.mindwalk.global.exception.BaseResponseStatus;
 
@@ -18,6 +24,9 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final WalkMissionRepository walkMissionRepository;
+	private final GardenRepository gardenRepository;
+	private final GardenPlantRepository gardenPlantRepository;
 
 	@Transactional
 	public void assignNickname(Long currentUserId, UserNicknameRequest request) {
@@ -28,7 +37,11 @@ public class UserService {
 	@Transactional(readOnly = true)
 	public UserInfoResponse getUserInfo(Long currentUserId) {
 		User user = findUserById(currentUserId);
-		return UserInfoResponse.from(user);
+		Long totalWalkCount = walkMissionRepository.countByUserAndStatus(user, WalkMissionStatus.COMPLETED);
+		Garden garden = gardenRepository.findByUserId(currentUserId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_GARDEN));
+		Long bloomedFlowerCount = gardenPlantRepository.countByGardenAndPlantStage(garden, PlantStage.FLOWER);
+		return UserInfoResponse.of(user, totalWalkCount, bloomedFlowerCount);
 	}
 
 	@Transactional

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/user/dto/response/UserInfoResponse.java
@@ -2,12 +2,24 @@ package com.goormthon.backend.mindwalk.domain.user.dto.response;
 
 import com.goormthon.backend.mindwalk.domain.user.domain.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserInfoResponse(
+	@Schema(description = "사용자 ID", example = "1")
 	Long userId,
-	String nickname
-	// boolean allowPushNotification
+	@Schema(description = "닉네임", example = "닉네임")
+	String nickname,
+	@Schema(description = "마음 산책한 날", example = "35")
+	Long totalWalkCount,
+	@Schema(description = "피운 꽃 개수", example = "100")
+	Long bloomedFlowerCount
 ) {
-	public static UserInfoResponse from(User user) {
-		return new UserInfoResponse(user.getId(), user.getNickname());
+	public static UserInfoResponse of(User user, Long totalWalkCount, Long bloomedFlowerCount) {
+		return new UserInfoResponse(
+			user.getId(),
+			user.getNickname(),
+			totalWalkCount,
+			bloomedFlowerCount
+		);
 	}
 }

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dao/WalkMissionRepository.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/walkmission/dao/WalkMissionRepository.java
@@ -17,4 +17,6 @@ public interface WalkMissionRepository extends JpaRepository<WalkMission, Long> 
 
 	boolean existsByUserAndStatusAndCompletedAtBetween(User user, WalkMissionStatus status, LocalDateTime start,
 		LocalDateTime end);
+
+	Long countByUserAndStatus(User user, WalkMissionStatus status);
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #31 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
#### 마이페이지 조회 API에 아래 필드 추가
- 총 산책 완료 횟수(`totalWalkCount`)
- 총 피운 꽃의 개수(`bloomedFlowerCount`)

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->