### PR TITLE
[Feat] 사용자가 수집한 꽃이 언제 피었는지 시간 정보 추가

### DIFF
--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/domain/GardenPlant.java
@@ -1,5 +1,7 @@
 package com.goormthon.backend.mindwalk.domain.garden.domain;
 
+import java.time.LocalDateTime;
+
 import com.goormthon.backend.mindwalk.domain.common.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -40,6 +42,9 @@ public class GardenPlant extends BaseTimeEntity {
 	@Column(name = "flower_type", nullable = false)
 	private FlowerType flowerType;
 
+	@Column(name = "bloomed_at")
+	private LocalDateTime bloomedAt;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "garden_id")
 	private Garden garden;
@@ -63,8 +68,9 @@ public class GardenPlant extends BaseTimeEntity {
 
 	public void addGrowthPoint(Long point) {
 		this.growthPoint += point;
-		if (this.growthPoint >= 150) {
+		if (this.growthPoint == 150) {
 			this.plantStage = PlantStage.FLOWER;
+			this.bloomedAt = LocalDateTime.now();
 		} else if (this.growthPoint >= 50) {
 			this.plantStage = PlantStage.SPROUT;
 		}

--- a/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dto/response/GetGardenInfoResponse.java
+++ b/src/main/java/com/goormthon/backend/mindwalk/domain/garden/dto/response/GetGardenInfoResponse.java
@@ -1,7 +1,9 @@
 package com.goormthon.backend.mindwalk.domain.garden.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.goormthon.backend.mindwalk.domain.garden.domain.GardenPlant;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -37,12 +39,16 @@ public record GetGardenInfoResponse(
 		@Schema(description = "수집한 꽃 ID", example = "2")
 		Long gardenPlantId,
 		@Schema(description = "꽃 종류", example = "해바라기")
-		String flowerType
+		String flowerType,
+		@Schema(description = "꽃이 핀 날짜", example = "2025-09-06")
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+		LocalDateTime bloomedAt
 	) {
 		public static UserFlower from(GardenPlant gardenPlant) {
 			return new UserFlower(
 				gardenPlant.getId(),
-				gardenPlant.getFlowerType().getValue()
+				gardenPlant.getFlowerType().getValue(),
+				gardenPlant.getBloomedAt()
 			);
 		}
 	}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #33 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

#### `GardenPlant` 엔티티에 `bloomedAt` 필드를 추가하여 꽃이 피는 시점을 기록
- 식물의 성장 포인트(`growthPoint`)가 150이 되면 `bloomedAt`에 현재 시간을 저장하도록 로직을 수정
- 정원 정보 조회 시(`GetGardenInfoResponse`), 사용자가 수집한 꽃의 개화 날짜(`bloomedAt`)를 "yyyy-MM-dd" 형식으로 반환하도록 DTO를 수정


## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->